### PR TITLE
Mise en perfdata de la métrique 'state'

### DIFF
--- a/nagios/check_mywebsite.py
+++ b/nagios/check_mywebsite.py
@@ -113,7 +113,7 @@ def output_nagios(name, timestamp, metrics, arguments, check_id, state_code_str)
             #  Data for the availabilty rate of the website ( Ok: 100 Warning: 50 Critical: 0 )
             if metric in ('state'):
                 perfdata.append(
-                perfdata2string(metric, value, '%', min=0, max=100)
+                    perfdata2string(metric, value, '%', min=0, max=100)
                 )
 
             elif metric in ('webtesttime'):

--- a/nagios/check_mywebsite.py
+++ b/nagios/check_mywebsite.py
@@ -110,8 +110,11 @@ def output_nagios(name, timestamp, metrics, arguments, check_id, state_code_str)
     for (metric, values) in metrics.items():
         for (location, value) in values.items():
 
+            #  Data for the availabilty rate of the website ( Ok: 100 Warning: 50 Critical: 0 )
             if metric in ('state'):
-                continue
+                perfdata.append(
+                perfdata2string(metric, value, '%', min=0, max=100)
+                )
 
             elif metric in ('webtesttime'):
                 perfdata.append(


### PR DESCRIPTION
Trois valeurs possibles : Ok = 100, Warning = 50, Critical = 0

Cette métrique permet de calculer le taux de disponibilité (en %) de la sonde "httpping" (check de base) en l'historisant et en la moyennant.
